### PR TITLE
Use asyncio.to_thread for IO

### DIFF
--- a/src/lobo/main.py
+++ b/src/lobo/main.py
@@ -12,17 +12,25 @@ from llama_index.llms.openai import OpenAI
 
 async def read_notes(ctx: Context):
     """Read notes from a markdown file"""
-    try:
+
+    def _read() -> str:
         with open("src/lobo/notes.md", "r") as file:
             return file.read()
+
+    try:
+        return await asyncio.to_thread(_read)
     except FileNotFoundError:
         return "No notes file found."
 
 
 async def write_refined_todos(ctx: Context, todos: str):
     """Write refined todos to a markdown file"""
-    with open("src/lobo/refined_todos.md", "w") as file:
-        file.write(todos)
+
+    def _write() -> None:
+        with open("src/lobo/refined_todos.md", "w") as file:
+            file.write(todos)
+
+    return await asyncio.to_thread(_write)
 
 
 def build_notes_organizer_agent(llm: OpenAI):


### PR DESCRIPTION
## Summary
- run file operations in `read_notes` and `write_refined_todos` via `asyncio.to_thread`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849463b0cac83309a2b1eef0a19ff88