### PR TITLE
Improve async helpers and docs, add pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # multi-agent-llama-index
-A simple multi-agent example built with llama index. 
+A simple multi-agent example built with LlamaIndex.
 
 Install dependencies
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ python = ">=3.12,<3.13"
 llama-index-core = "^0.12.4"
 llama-index-llms-openai = "^0.4.0"
 
+[tool.poetry.dev-dependencies]
+pytest = "^8.1.1"
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/lobo/main.py
+++ b/src/lobo/main.py
@@ -11,18 +11,26 @@ from llama_index.llms.openai import OpenAI
 
 
 async def read_notes(ctx: Context):
-    """Read notes from a markdown file"""
-    try:
-        with open("src/lobo/notes.md", "r") as file:
-            return file.read()
-    except FileNotFoundError:
-        return "No notes file found."
+    """Read notes from a markdown file asynchronously"""
+
+    def _read():
+        try:
+            with open("src/lobo/notes.md", "r") as file:
+                return file.read()
+        except FileNotFoundError:
+            return "No notes file found."
+
+    return await asyncio.to_thread(_read)
 
 
 async def write_refined_todos(ctx: Context, todos: str):
-    """Write refined todos to a markdown file"""
-    with open("src/lobo/refined_todos.md", "w") as file:
-        file.write(todos)
+    """Write refined todos to a markdown file asynchronously"""
+
+    def _write():
+        with open("src/lobo/refined_todos.md", "w") as file:
+            file.write(todos)
+
+    await asyncio.to_thread(_write)
 
 
 def build_notes_organizer_agent(llm: OpenAI):
@@ -76,7 +84,7 @@ async def main():
             """
     )
 
-    # INFO: to see what is happening during the workflow execution 
+    # Print workflow events to follow execution progress
     current_agent = None
     async for event in handler.stream_events():
         if (hasattr(event, 'current_agent_name') and

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,32 @@
+import asyncio
+import builtins
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+from lobo.main import read_notes, write_refined_todos
+
+
+@pytest.mark.asyncio
+async def test_read_and_write_notes(tmp_path, monkeypatch):
+    notes_file = tmp_path / "notes.md"
+    refined_file = tmp_path / "refined_todos.md"
+
+    notes_file.write_text("example notes")
+
+    def fake_open(path, mode="r", *args, **kwargs):
+        if path == "src/lobo/notes.md":
+            return builtins.open(notes_file, mode, *args, **kwargs)
+        if path == "src/lobo/refined_todos.md":
+            return builtins.open(refined_file, mode, *args, **kwargs)
+        return builtins.open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    content = await read_notes(None)
+    assert content == "example notes"
+
+    await write_refined_todos(None, "todo")
+    assert refined_file.read_text() == "todo"


### PR DESCRIPTION
## Summary
- fix typo in README for consistent "LlamaIndex" name
- use non-blocking file I/O in note helper functions
- clarify logging comment in workflow
- add basic pytest for note utilities
- add pytest dev dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_e_68494528259c8330991adab99993c8ab